### PR TITLE
in order to modify the message

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -19,10 +19,9 @@ module.exports = (function() {
 
 	// main log method
 	var _log = function(level, title, format, filters, needstack, args) {
-		var msg = utils.format.apply(this, args);
 		var data = {
 			timestamp : dateFormat(new Date(), _config.dateformat),
-			message : msg,
+			message : "",
 			title : title,
 			level : level,
 			args : args
@@ -50,6 +49,8 @@ module.exports = (function() {
 		}
 
 		_config.preprocess(data);
+		var msg = utils.format.apply(this, data.args);
+		data.message = msg;
 
 		// call micro-template to ouput
 		data.output = tinytim.tim(format, data);


### PR DESCRIPTION
If I set object to args, args is converted into string by util.inspect.
Because all information of object is displayed, it reduce readability of log.
I want to modify args in preprocess. (delete, update, etc..)
Therefore data.message is set after preprocess.
Please check the change.

Best regards.
