### PR TITLE
get the filename correctly on windows

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -1,4 +1,4 @@
-var tinytim = require('tinytim'), dateFormat = require('dateformat'), utils = require('./utils')
+var tinytim = require('tinytim'), dateFormat = require('dateformat'), utils = require('./utils'), path = require('path')
 module.exports = (function() {
 	// default config
 	var _config = {
@@ -47,7 +47,7 @@ module.exports = (function() {
 				data.path = sp[2];
 				data.line = sp[3];
 				data.pos = sp[4];
-				var paths = data.path.split('/');
+				var paths = data.path.split(path.sep);
 				data.file = paths[paths.length - 1];
 			}
 		}


### PR DESCRIPTION
replaced the "/" with path.sep - this will allow our windows using friends nicer log messages.

observed: 

013-10-16T15:23:26.139Z <info> c:\oh\god\it\hurts\why\oh\why\lovelycode.js:35 ()  well this is great

expected:

013-10-16T15:23:26.139Z <info> lovelycode.js:35 () this is better
