### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "version": "0.7.3",
   "author": "LI Long <lilong@gmail.com>",
+  "license": "MIT",
   "dependencies": {
     "dateformat": "1.0.2-1.2.3",
     "colors": "~0.6.2",


### PR DESCRIPTION
Allows license to be read programatically.
