### PR TITLE
Added getter for log level

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,4 +7,4 @@ exports.dailyfile = require('./dailyfile');
 var settings = require('./settings');
 exports.close = settings.close;
 exports.setLevel = settings.setLevel;
-
+exports.getLevel = settings.getLevel;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -10,10 +10,15 @@ var close = function(){
 //dynamically change the log level, all of output
 var setLevel = function(level){
 	settings.level = level;
+}
 
+//get the current log level
+var getLevel = function(){
+	return settings.level;
 }
 
 
 exports.settings = settings;
 exports.close = close;
 exports.setLevel = setLevel;
+exports.getLevel = getLevel;


### PR DESCRIPTION
Dynamically setting the log level is a really nice feature. But to get and set the log level in an applications admin settings, we need to read the current log level as well.