### PR TITLE
Enable use of tracer in strict mode

### DIFF
--- a/lib/dailyfile.js
+++ b/lib/dailyfile.js
@@ -22,7 +22,9 @@ module.exports = function (conf) {
         this.stream = fs.createWriteStream(this.path, {
             flags: "a",
             encoding: "utf8",
-            mode: 0666
+            mode: parseInt('0644', 8)
+	    // When engines node >= 4.0.0, following notation will be better:
+            //mode: 0o644
         });
     }
 


### PR DESCRIPTION
Without this modification one gets the following:

    $ node --use_strict app.js
    tracer/lib/dailyfile.js:25
                mode: 0666
                      ^^^^

    SyntaxError: Octal literals are not allowed in strict mode.

So this commit is not about fixing an error, but being more friendly for people running Node.js applications in strict mode and in general being more ready for the future.