### PR TITLE
Adding type definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,10 @@ node_js:
   - 0.12
   - 0.10
   - 8
-  - 9
+
+matrix:
+  include:
+    - node_js: 9
+      script:
+        - npm install dtslint@^0.3
+        - npm run dtslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ matrix:
   include:
     - node_js: node
       script:
+        - npm test
         - npm install dtslint@^0.3
         - npm run dtslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ node_js:
   - 0.12
   - 0.10
   - 8
+  - 9
 
 matrix:
   include:
-    - node_js: 9
+    - node_js: node
       script:
         - npm install dtslint@^0.3
         - npm run dtslint

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,81 @@
+// TypeScript Version: 2.6
+
+export namespace Tracer {
+    interface LogOutput {
+        timestamp: string;
+        message: string;
+        title: string;
+        level: number;
+        args: any[];
+        method: string;
+        path: string;
+        line: string;
+        pos: string;
+        file: string;
+        stack: string[];
+        /* The output to be written */
+        output: string;
+    }
+
+    type FilterFunction = (data: string) => string | void;
+    type TransportFunction = (data: string) => void;
+
+    interface LoggerConfig {
+        /**
+         * Output format (Using `tinytim` templating)
+         *
+         * Defaults to: "{{timestamp}} <{{title}}> {{file}}:{{line}} ({{method}}) {{message}}"
+         * Possible values:
+         * - timestamp: current time
+         * - title: method name, default is 'log', 'trace', 'debug', 'info', 'warn', 'error','fatal'
+         * - level: method level, default is 'log':0, 'trace':1, 'debug':2, 'info':3, 'warn':4, 'error':5, 'fatal':6
+         * - message: printf message, support %s string, %d number, %j JSON and auto inspect
+         * - file: file name
+         * - line: line number
+         * - pos: position
+         * - path: file's path
+         * - method: method name of caller
+         * - stack: call stack message
+         */
+        format?: string;
+        dateformat?: string;
+        filters?: FilterFunction[];
+        level?: string;
+        methods?: string[];
+        /* get the specified index of stack as file information. It is userful for development package. */
+        stackIndex?: number;
+        inspectOpt?: {
+            /* if true then the object's non-enumerable properties will be shown too. Defaults to false */
+            showHidden: boolean,
+            /**
+             * Tells inspect how many times to recurse while formatting the object.
+             * This is useful for inspecting large complicated objects.
+             * Defaults to 2. To make it recurse indefinitely pass null.
+             */
+            depth: number
+        };
+
+        /* Pre-process the log object. */
+        preprocess?(data: LogOutput): void;
+        /* Transport function (e.g. console.log) */
+        transport?: TransportFunction | TransportFunction[];
+    }
+
+    interface Logger {
+        log(...args: any[]): LogOutput;
+        trace(...args: any[]): LogOutput;
+        debug(...args: any[]): LogOutput;
+        info(...args: any[]): LogOutput;
+        warn(...args: any[]): LogOutput;
+        error(...args: any[]): LogOutput;
+        fatal(...args: any[]): LogOutput;
+    }
+}
+
+export function colorConsole(config?: Tracer.LoggerConfig): Tracer.Logger;
+export function console(config?: Tracer.LoggerConfig): Tracer.Logger;
+export function dailyfile(config?: Tracer.LoggerConfig): Tracer.Logger;
+
+export function close(): void;
+export function setLevel(level: number | string): void;
+export function getLevel(): number | string;

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "eslint": "^2.13.1",
     "expresso": "^0.9.2",
     "istanbul": "^0.4.5",
-    "mongoskin": "0.3.0"
+    "mongoskin": "0.3.0",
+    "tslint": "^5.9.1"
   },
   "main": "./lib/index",
+  "types": "./lib/index.d.ts",
   "keywords": [
     "log",
     "logger",
@@ -34,7 +36,8 @@
     "lint": "eslint .",
     "posttest": "npm run lint",
     "test:coverage": "istanbul cover expresso test/*.js",
-    "posttest:coverage": "npm run lint"
+    "posttest:coverage": "npm run lint",
+    "dtslint": "dtslint ."
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}


### PR DESCRIPTION
Adding TypeScript definitions allowing IDEs to auto-complete the usage of this library.

Note about testing: as `dtslint` requires node 4 and above, we will only perform the definitions linting on the highest node version (10 currently, or "node") being tested. Earlier versions will have issues installing `dtslint`, so I excluded that from _package.json_.