### PR TITLE
Added {{folder}} template option for parent folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ format tag:
 *  line: line number
 *  pos: position
 *  path: file's path
+*  folder: file's parent folder
 *  method: method name of caller
 *  stack: call stack message
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -27,7 +27,7 @@ function logMain(config, level, title, format, filters, needstack, args) {
 		level : level,
 		args : args
 	};
-	data.method = data.path = data.line = data.pos = data.file = '';
+	data.method = data.path = data.line = data.pos = data.file = data.folder = '';
 
 	if (needstack) {
 		// get call stack, and analyze it
@@ -41,6 +41,7 @@ function logMain(config, level, title, format, filters, needstack, args) {
 			data.line = sp[3];
 			data.pos = sp[4];
 			data.file = path.basename(data.path);
+			data.folder = path.basename(path.dirname(data.path));
 			data.stack = stacklist.join('\n');
 		}
 	}
@@ -130,7 +131,7 @@ module.exports = (function() {
 			var format = _config.format[0];
 			if (_config.format.length === 2 && _config.format[1][title])
 				format = _config.format[1][title];
-			var needstack = /{{(method|path|line|pos|file|stack)}}/i.test(format);
+			var needstack = /{{(method|path|line|pos|file|folder|stack)}}/i.test(format);
 
 			var filters;
 			if (lastFilter && lastFilter[title])

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git://github.com/baryon/tracer.git"
   },
-  "version": "0.9.6",
+  "version": "0.9.7",
   "author": "LI Long <lilong@gmail.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I have a project that I'm using tracer for logging which has several scripts that use the same name, but are in different parent folders.  I didn't want to print the full path to the file in every log entry, but I needed a way to differentiate between the scripts, so I added a `{{parent}}` folder template option.

For example: if you are using tracer for logging for script being executed: `/some/really/long/path/to/scripts/module1/node_helper.js`, then using `{{folder}}/{{file}}` in your tracer console config would return: `module1/node_helper.js`.

