### PR TITLE
Add option to overwrite the default console methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,10 +484,20 @@ Read examples please. [setLevel.js](https://github.com/baryon/tracer/blob/master
 support count, assert and table methods.
 Read examples please. [consoleMethods.js](https://github.com/baryon/tracer/blob/master/example/consoleMethods.js)
 
+### Override the Default `console.log()`, `console.error()` functions globally
+
+Setting `overwriteConsoleMethods` option which will overwrite the default `console` operations. To use, declare `logger = require('tracer')({overwriteConsoleMethods: true})`. Once this is called, any `console.log()` or similar call will use Tracer to process the output. See example [consoleOverwrite.js](blob/master/example/consoleMethods.js).
+
 
 More features, please read examples.
 
 ## History
+
+### 0.9.8
+* Added `overwriteConsoleMethods` option which will overwrite the default `console` operations.
+
+### 0.9.7
+* Added `{{folder}}` template type to return script's parent folder.
 
 ### 0.9.5
 * Fixed. Update index.d.ts and dtslint for typescript. #92 and #94 by @Diluka. 

--- a/example/consoleOverwrite.js
+++ b/example/consoleOverwrite.js
@@ -1,0 +1,13 @@
+"use strict";
+var logger = require('tracer').console({ overwriteConsoleMethods: true });
+
+console.log('hello');
+console.trace('hello', 'world');
+console.debug('hello %s',  'world', 123);
+console.info('hello %s %d',  'world', 123, {foo:'bar'});
+console.warn('hello %s %d %j', 'world', 123, {foo:'bar'});
+console.error('hello %s %d %j', 'world', 123, {foo:'bar'}, [1, 2, 3, 4], Object);
+
+eval("console.log('hello');");
+
+

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,10 +1,22 @@
 "use strict";
-var tinytim = require('tinytim'), dateFormat = require('dateformat'), utils = require('./utils'), path = require('path'), settings = require('./settings').settings;
+var tinytim = require('tinytim'),
+    dateFormat = require('dateformat'),
+    utils = require('./utils'),
+    path = require('path'),
+    settings = require('./settings').settings;
 
-var noop = function(){};
+var noop = function() {};
 
-var fwrap = function(fn){
-	return function(str){ return fn(str) };
+var fwrap = function(fn) {
+    return function(str) { return fn(str) };
+};
+
+var defaultConsoleFunctions = {
+    log: console.log.bind(console),
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    debug: (console.debug || console.log).bind(console)
 };
 
 // Stack trace format :
@@ -14,146 +26,159 @@ var stackReg2 = /at\s+()(.*):(\d*):(\d*)/i;
 
 // main log method
 function logMain(config, level, title, format, filters, needstack, args) {
-	//check level of global settings
-	var gLevel = settings.level;
-	if (typeof (gLevel) == 'string')
-		gLevel = config.methods.indexOf(gLevel);
-	if (level < gLevel) { return; }
+    //check level of global settings
+    var gLevel = settings.level;
+    if (typeof(gLevel) == 'string')
+        gLevel = config.methods.indexOf(gLevel);
+    if (level < gLevel) { return; }
 
-	var data = {
-		timestamp : dateFormat(new Date(), config.dateformat),
-		message : "",
-		title : title,
-		level : level,
-		args : args
-	};
-	data.method = data.path = data.line = data.pos = data.file = data.folder = '';
+    var data = {
+        timestamp: dateFormat(new Date(), config.dateformat),
+        message: "",
+        title: title,
+        level: level,
+        args: args
+    };
+    data.method = data.path = data.line = data.pos = data.file = data.folder = '';
 
-	if (needstack) {
-		// get call stack, and analyze it
-		// get all file,method and line number
-		var stacklist = (new Error()).stack.split('\n').slice(3);
-		var s = stacklist[config.stackIndex] || stacklist[0],
-			sp = stackReg.exec(s) || stackReg2.exec(s);
-		if (sp && sp.length === 5) {
-			data.method = sp[1];
-			data.path = sp[2];
-			data.line = sp[3];
-			data.pos = sp[4];
-			data.file = path.basename(data.path);
-			data.folder = path.basename(path.dirname(data.path));
-			data.stack = stacklist.join('\n');
-		}
-	}
+    if (needstack) {
+        // get call stack, and analyze it
+        // get all file,method and line number
+        var stacklist = (new Error()).stack.split('\n').slice(3);
+        var s = stacklist[config.stackIndex] || stacklist[0],
+            sp = stackReg.exec(s) || stackReg2.exec(s);
+        if (sp && sp.length === 5) {
+            data.method = sp[1];
+            data.path = sp[2];
+            data.line = sp[3];
+            data.pos = sp[4];
+            data.file = path.basename(data.path);
+            data.folder = path.basename(path.dirname(data.path));
+            data.stack = stacklist.join('\n');
+        }
+    }
 
-	config.preprocess(data);
-	var msg = utils.format.apply(config, data.args);
-	data.message = msg;
+    config.preprocess(data);
+    var msg = utils.format.apply(config, data.args);
+    data.message = msg;
 
-	// call micro-template to ouput
-	data.output = tinytim.tim(format, data);
-	
-	// save unprocessed output
-	data.rawoutput = data.output;
+    // call micro-template to ouput
+    data.output = tinytim.tim(format, data);
 
-	// process every filter method
-	var len = filters.length;
-	for ( var i = 0; i < len; i += 1) {
-		data.output = fwrap(filters[i])(data.output);
-		if (!data.output)
-			return data;
-		// cancel next process if return a false(include null, undefined)
-	}
-	// trans the final result
-	config.transport.forEach(function(tras) {
-		tras(data);
-	});
-	return data;
+    // save unprocessed output
+    data.rawoutput = data.output;
+
+    // process every filter method
+    var len = filters.length;
+    for (var i = 0; i < len; i += 1) {
+        data.output = fwrap(filters[i])(data.output);
+        if (!data.output)
+            return data;
+        // cancel next process if return a false(include null, undefined)
+    }
+    // trans the final result
+    if (!config.overwriteConsoleMethods) {
+        config.transport.forEach(function(tras) {
+            tras(data);
+        });
+    }
+    return data;
 }
 
 module.exports = (function() {
-	// default config
-	var _config = {
-		format : "{{timestamp}} <{{title}}> {{file}}:{{line}} ({{method}}) {{message}}",
-		dateformat : "isoDateTime",
-		preprocess : function() {
-		},
-		transport : function(data) {
-			if (data.level >= 4) { // warn and more critical
-				console.error(data.output);
-			} else {
-				console.log(data.output);
-			}
-		},
-		filters : [],
-		level : 'log',
-		methods : [ 'log', 'trace', 'debug', 'info', 'warn', 'error', 'fatal' ],
-		stackIndex : 0,		// get the specified index of stack as file information. It is userful for development package.
-		inspectOpt : {
-			showHidden : false, //if true then the object's non-enumerable properties will be shown too. Defaults to false
-			depth : 2 //tells inspect how many times to recurse while formatting the object. This is useful for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
-		},
-		supportConsoleMethods : true
-	};
+    // default config
+    var _config = {
+        format: "{{timestamp}} <{{title}}> {{file}}:{{line}} ({{method}}) {{message}}",
+        dateformat: "isoDateTime",
+        preprocess: function() {},
+        transport: function(data) {
+            if (data.level >= 4) { // warn and more critical
+                console.error(data.output);
+            } else {
+                console.log(data.output);
+            }
+        },
+        filters: [],
+        level: 'log',
+        methods: ['log', 'trace', 'debug', 'info', 'warn', 'error', 'fatal'],
+        stackIndex: 0, // get the specified index of stack as file information. It is userful for development package.
+        inspectOpt: {
+            showHidden: false, //if true then the object's non-enumerable properties will be shown too. Defaults to false
+            depth: 2 //tells inspect how many times to recurse while formatting the object. This is useful for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
+        },
+        supportConsoleMethods: true,
+        overwriteConsoleMethods: false
+    };
 
-	var userConfig = arguments;
-	if(typeof userConfig[0] === 'string') {
-		userConfig = [require(userConfig[0])];
-	}
+    var userConfig = arguments;
+    if (typeof userConfig[0] === 'string') {
+        userConfig = [require(userConfig[0])];
+    }
 
-	// union user's config and default
-	_config = utils.union(_config, userConfig);
+    // union user's config and default
+    _config = utils.union(_config, userConfig);
 
-	var _self = {};
+    var _self = {};
 
-	_config.format = Array.isArray(_config.format) ? _config.format
-		: [ _config.format ];
+    _config.format = Array.isArray(_config.format) ? _config.format :
+        [_config.format];
 
-	_config.filters = Array.isArray(_config.filters) ? _config.filters
-		: [ _config.filters ];
+    _config.filters = Array.isArray(_config.filters) ? _config.filters :
+        [_config.filters];
 
-	_config.transport = Array.isArray(_config.transport) ? _config.transport : [_config.transport];
+    _config.transport = Array.isArray(_config.transport) ? _config.transport : [_config.transport];
 
-	var fLen = _config.filters.length, lastFilter;
-	if (fLen > 0)
-		if (Object.prototype.toString.call(_config.filters[--fLen]) != '[object Function]') {
-			lastFilter = _config.filters[fLen];
-			_config.filters = _config.filters.slice(0, fLen);
-		}
+    var fLen = _config.filters.length,
+        lastFilter;
+    if (fLen > 0)
+        if (Object.prototype.toString.call(_config.filters[--fLen]) != '[object Function]') {
+            lastFilter = _config.filters[fLen];
+            _config.filters = _config.filters.slice(0, fLen);
+        }
 
-	if (typeof (_config.level) == 'string')
-		_config.level = _config.methods.indexOf(_config.level);
+    if (typeof(_config.level) == 'string')
+        _config.level = _config.methods.indexOf(_config.level);
 
-	_config.methods.forEach(function(title, i) {
-		if (i < _config.level)
-			_self[title] = noop;
-		else {
-			var format = _config.format[0];
-			if (_config.format.length === 2 && _config.format[1][title])
-				format = _config.format[1][title];
-			var needstack = /{{(method|path|line|pos|file|folder|stack)}}/i.test(format);
+    _config.methods.forEach(function(title, i) {
+        if (i < _config.level)
+            _self[title] = noop;
+        else {
+            var format = _config.format[0];
+            if (_config.format.length === 2 && _config.format[1][title])
+                format = _config.format[1][title];
+            var needstack = /{{(method|path|line|pos|file|folder|stack)}}/i.test(format);
 
-			var filters;
-			if (lastFilter && lastFilter[title])
-				filters = Array.isArray(lastFilter[title]) ? lastFilter[title]
-					: [ lastFilter[title] ];
-			else
-				filters = _config.filters;
+            var filters;
+            if (lastFilter && lastFilter[title])
+                filters = Array.isArray(lastFilter[title]) ? lastFilter[title] :
+                [lastFilter[title]];
+            else
+                filters = _config.filters;
 
-			// interface
-			_self[title] = function() {
-				return logMain(_config, i, title, format, filters, needstack, arguments);
-			};
-		}
-	});
+            // interface
+            _self[title] = function() {
+                return logMain(_config, i, title, format, filters, needstack, arguments);
+            };
+        }
+    });
 
-	if(_config.supportConsoleMethods) {
-		Object.getOwnPropertyNames(console).forEach(function(title) {
-			if (!_self[title]) {
-				_self[title] = console[title];
-			}
-		});
-	}
+    if (_config.supportConsoleMethods) {
+        Object.getOwnPropertyNames(console).forEach(function(title) {
+            if (!_self[title]) {
+                _self[title] = console[title];
+            }
+        });
+    }
 
-	return _self;
+    if (_config.overwriteConsoleMethods) {
+        Object.keys(defaultConsoleFunctions).forEach(function(title) {
+            console[title] = function() {
+            	var s = _self[title]().output;
+                arguments[0] = utils.format(s, arguments[0]);
+                defaultConsoleFunctions[title].apply(console, arguments);
+            };
+        });
+    }
+
+    return _self;
 });

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,14 +1,10 @@
 "use strict";
-var tinytim = require('tinytim'),
-    dateFormat = require('dateformat'),
-    utils = require('./utils'),
-    path = require('path'),
-    settings = require('./settings').settings;
+var tinytim = require('tinytim'), dateFormat = require('dateformat'), utils = require('./utils'), path = require('path'), settings = require('./settings').settings;
 
-var noop = function() {};
+var noop = function(){};
 
-var fwrap = function(fn) {
-    return function(str) { return fn(str) };
+var fwrap = function(fn){
+	return function(str){ return fn(str) };
 };
 
 var defaultConsoleFunctions = {
@@ -26,149 +22,148 @@ var stackReg2 = /at\s+()(.*):(\d*):(\d*)/i;
 
 // main log method
 function logMain(config, level, title, format, filters, needstack, args) {
-    //check level of global settings
-    var gLevel = settings.level;
-    if (typeof(gLevel) == 'string')
-        gLevel = config.methods.indexOf(gLevel);
-    if (level < gLevel) { return; }
+	//check level of global settings
+	var gLevel = settings.level;
+	if (typeof (gLevel) == 'string')
+		gLevel = config.methods.indexOf(gLevel);
+	if (level < gLevel) { return; }
 
-    var data = {
-        timestamp: dateFormat(new Date(), config.dateformat),
-        message: "",
-        title: title,
-        level: level,
-        args: args
-    };
-    data.method = data.path = data.line = data.pos = data.file = data.folder = '';
+	var data = {
+		timestamp : dateFormat(new Date(), config.dateformat),
+		message : "",
+		title : title,
+		level : level,
+		args : args
+	};
+	data.method = data.path = data.line = data.pos = data.file = data.folder = '';
 
-    if (needstack) {
-        // get call stack, and analyze it
-        // get all file,method and line number
-        var stacklist = (new Error()).stack.split('\n').slice(3);
-        var s = stacklist[config.stackIndex] || stacklist[0],
-            sp = stackReg.exec(s) || stackReg2.exec(s);
-        if (sp && sp.length === 5) {
-            data.method = sp[1];
-            data.path = sp[2];
-            data.line = sp[3];
-            data.pos = sp[4];
-            data.file = path.basename(data.path);
-            data.folder = path.basename(path.dirname(data.path));
-            data.stack = stacklist.join('\n');
-        }
-    }
+	if (needstack) {
+		// get call stack, and analyze it
+		// get all file,method and line number
+		var stacklist = (new Error()).stack.split('\n').slice(3);
+		var s = stacklist[config.stackIndex] || stacklist[0],
+			sp = stackReg.exec(s) || stackReg2.exec(s);
+		if (sp && sp.length === 5) {
+			data.method = sp[1];
+			data.path = sp[2];
+			data.line = sp[3];
+			data.pos = sp[4];
+			data.file = path.basename(data.path);
+			data.folder = path.basename(path.dirname(data.path));
+			data.stack = stacklist.join('\n');
+		}
+	}
 
-    config.preprocess(data);
-    var msg = utils.format.apply(config, data.args);
-    data.message = msg;
+	config.preprocess(data);
+	var msg = utils.format.apply(config, data.args);
+	data.message = msg;
 
-    // call micro-template to ouput
-    data.output = tinytim.tim(format, data);
+	// call micro-template to ouput
+	data.output = tinytim.tim(format, data);
+	
+	// save unprocessed output
+	data.rawoutput = data.output;
 
-    // save unprocessed output
-    data.rawoutput = data.output;
-
-    // process every filter method
-    var len = filters.length;
-    for (var i = 0; i < len; i += 1) {
-        data.output = fwrap(filters[i])(data.output);
-        if (!data.output)
-            return data;
-        // cancel next process if return a false(include null, undefined)
-    }
-    // trans the final result
+	// process every filter method
+	var len = filters.length;
+	for ( var i = 0; i < len; i += 1) {
+		data.output = fwrap(filters[i])(data.output);
+		if (!data.output)
+			return data;
+		// cancel next process if return a false(include null, undefined)
+	}
+	// trans the final result
     if (!config.overwriteConsoleMethods) {
         config.transport.forEach(function(tras) {
             tras(data);
         });
     }
-    return data;
+	return data;
 }
 
 module.exports = (function() {
-    // default config
-    var _config = {
-        format: "{{timestamp}} <{{title}}> {{file}}:{{line}} ({{method}}) {{message}}",
-        dateformat: "isoDateTime",
-        preprocess: function() {},
-        transport: function(data) {
-            if (data.level >= 4) { // warn and more critical
-                console.error(data.output);
-            } else {
-                console.log(data.output);
-            }
-        },
-        filters: [],
-        level: 'log',
-        methods: ['log', 'trace', 'debug', 'info', 'warn', 'error', 'fatal'],
-        stackIndex: 0, // get the specified index of stack as file information. It is userful for development package.
-        inspectOpt: {
-            showHidden: false, //if true then the object's non-enumerable properties will be shown too. Defaults to false
-            depth: 2 //tells inspect how many times to recurse while formatting the object. This is useful for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
-        },
-        supportConsoleMethods: true,
-        overwriteConsoleMethods: false
-    };
+	// default config
+	var _config = {
+		format : "{{timestamp}} <{{title}}> {{file}}:{{line}} ({{method}}) {{message}}",
+		dateformat : "isoDateTime",
+		preprocess : function() {
+		},
+		transport : function(data) {
+			if (data.level >= 4) { // warn and more critical
+				console.error(data.output);
+			} else {
+				console.log(data.output);
+			}
+		},
+		filters : [],
+		level : 'log',
+		methods : [ 'log', 'trace', 'debug', 'info', 'warn', 'error', 'fatal' ],
+		stackIndex : 0,		// get the specified index of stack as file information. It is userful for development package.
+		inspectOpt : {
+			showHidden : false, //if true then the object's non-enumerable properties will be shown too. Defaults to false
+			depth : 2 //tells inspect how many times to recurse while formatting the object. This is useful for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
+		},
+		supportConsoleMethods : true
+	};
 
-    var userConfig = arguments;
-    if (typeof userConfig[0] === 'string') {
-        userConfig = [require(userConfig[0])];
-    }
+	var userConfig = arguments;
+	if(typeof userConfig[0] === 'string') {
+		userConfig = [require(userConfig[0])];
+	}
 
-    // union user's config and default
-    _config = utils.union(_config, userConfig);
+	// union user's config and default
+	_config = utils.union(_config, userConfig);
 
-    var _self = {};
+	var _self = {};
 
-    _config.format = Array.isArray(_config.format) ? _config.format :
-        [_config.format];
+	_config.format = Array.isArray(_config.format) ? _config.format
+		: [ _config.format ];
 
-    _config.filters = Array.isArray(_config.filters) ? _config.filters :
-        [_config.filters];
+	_config.filters = Array.isArray(_config.filters) ? _config.filters
+		: [ _config.filters ];
 
-    _config.transport = Array.isArray(_config.transport) ? _config.transport : [_config.transport];
+	_config.transport = Array.isArray(_config.transport) ? _config.transport : [_config.transport];
 
-    var fLen = _config.filters.length,
-        lastFilter;
-    if (fLen > 0)
-        if (Object.prototype.toString.call(_config.filters[--fLen]) != '[object Function]') {
-            lastFilter = _config.filters[fLen];
-            _config.filters = _config.filters.slice(0, fLen);
-        }
+	var fLen = _config.filters.length, lastFilter;
+	if (fLen > 0)
+		if (Object.prototype.toString.call(_config.filters[--fLen]) != '[object Function]') {
+			lastFilter = _config.filters[fLen];
+			_config.filters = _config.filters.slice(0, fLen);
+		}
 
-    if (typeof(_config.level) == 'string')
-        _config.level = _config.methods.indexOf(_config.level);
+	if (typeof (_config.level) == 'string')
+		_config.level = _config.methods.indexOf(_config.level);
 
-    _config.methods.forEach(function(title, i) {
-        if (i < _config.level)
-            _self[title] = noop;
-        else {
-            var format = _config.format[0];
-            if (_config.format.length === 2 && _config.format[1][title])
-                format = _config.format[1][title];
-            var needstack = /{{(method|path|line|pos|file|folder|stack)}}/i.test(format);
+	_config.methods.forEach(function(title, i) {
+		if (i < _config.level)
+			_self[title] = noop;
+		else {
+			var format = _config.format[0];
+			if (_config.format.length === 2 && _config.format[1][title])
+				format = _config.format[1][title];
+			var needstack = /{{(method|path|line|pos|file|folder|stack)}}/i.test(format);
 
-            var filters;
-            if (lastFilter && lastFilter[title])
-                filters = Array.isArray(lastFilter[title]) ? lastFilter[title] :
-                [lastFilter[title]];
-            else
-                filters = _config.filters;
+			var filters;
+			if (lastFilter && lastFilter[title])
+				filters = Array.isArray(lastFilter[title]) ? lastFilter[title]
+					: [ lastFilter[title] ];
+			else
+				filters = _config.filters;
 
-            // interface
-            _self[title] = function() {
-                return logMain(_config, i, title, format, filters, needstack, arguments);
-            };
-        }
-    });
+			// interface
+			_self[title] = function() {
+				return logMain(_config, i, title, format, filters, needstack, arguments);
+			};
+		}
+	});
 
-    if (_config.supportConsoleMethods) {
-        Object.getOwnPropertyNames(console).forEach(function(title) {
-            if (!_self[title]) {
-                _self[title] = console[title];
-            }
-        });
-    }
+	if(_config.supportConsoleMethods) {
+		Object.getOwnPropertyNames(console).forEach(function(title) {
+			if (!_self[title]) {
+				_self[title] = console[title];
+			}
+		});
+	}
 
     if (_config.overwriteConsoleMethods) {
         Object.keys(defaultConsoleFunctions).forEach(function(title) {
@@ -179,6 +174,6 @@ module.exports = (function() {
             };
         });
     }
-
-    return _self;
+    
+	return _self;
 });

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,5 +1,5 @@
 "use strict";
-const { Console } = require('console');
+var Console = require('console').Console;
 var printer = new Console(process.stdout, process.stderr);
 
 var tinytim = require('tinytim'), dateFormat = require('dateformat'), utils = require('./utils'), path = require('path'), settings = require('./settings').settings;

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,18 +1,13 @@
 "use strict";
+const { Console } = require('console');
+var printer = new Console(process.stdout, process.stderr);
+
 var tinytim = require('tinytim'), dateFormat = require('dateformat'), utils = require('./utils'), path = require('path'), settings = require('./settings').settings;
 
 var noop = function(){};
 
 var fwrap = function(fn){
 	return function(str){ return fn(str) };
-};
-
-var defaultConsoleFunctions = {
-    log: console.log.bind(console),
-    info: console.info.bind(console),
-    warn: console.warn.bind(console),
-    error: console.error.bind(console),
-    debug: (console.debug || console.log).bind(console)
 };
 
 // Stack trace format :
@@ -73,11 +68,9 @@ function logMain(config, level, title, format, filters, needstack, args) {
 		// cancel next process if return a false(include null, undefined)
 	}
 	// trans the final result
-    if (!config.overwriteConsoleMethods) {
-        config.transport.forEach(function(tras) {
-            tras(data);
-        });
-    }
+    config.transport.forEach(function(tras) {
+        tras(data);
+    });
 	return data;
 }
 
@@ -90,9 +83,9 @@ module.exports = (function() {
 		},
 		transport : function(data) {
 			if (data.level >= 4) { // warn and more critical
-				console.error(data.output);
+				printer.error(data.output);
 			} else {
-				console.log(data.output);
+				printer.log(data.output);
 			}
 		},
 		filters : [],
@@ -103,7 +96,8 @@ module.exports = (function() {
 			showHidden : false, //if true then the object's non-enumerable properties will be shown too. Defaults to false
 			depth : 2 //tells inspect how many times to recurse while formatting the object. This is useful for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
 		},
-		supportConsoleMethods : true
+		supportConsoleMethods : true,
+		overwriteConsoleMethods: false
 	};
 
 	var userConfig = arguments;
@@ -154,6 +148,10 @@ module.exports = (function() {
 			_self[title] = function() {
 				return logMain(_config, i, title, format, filters, needstack, arguments);
 			};
+
+		    if (_config.overwriteConsoleMethods) {
+		        console[title] = _self[title];
+		    }
 		}
 	});
 
@@ -164,16 +162,6 @@ module.exports = (function() {
 			}
 		});
 	}
-
-    if (_config.overwriteConsoleMethods) {
-        Object.keys(defaultConsoleFunctions).forEach(function(title) {
-            console[title] = function() {
-            	var s = _self[title]().output;
-                arguments[0] = utils.format(s, arguments[0]);
-                defaultConsoleFunctions[title].apply(console, arguments);
-            };
-        });
-    }
     
 	return _self;
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git://github.com/baryon/tracer.git"
   },
-  "version": "0.9.7",
+  "version": "0.9.8",
   "author": "LI Long <lilong@gmail.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Not sure if you want this or not, but I added an option to overwrite the default console.log (etc..) methods once Tracer is declared. Basically, if you already have a script with a bunch of console.log, console.error, etc. statements in it, you can add at the top of the file:
```js
var logger = require('tracer').console({ overwriteConsoleMethods: true });
```
And they will all print using tracer's formatting.  See the example below.

Based off of the `logprefix` node module.