### PR TITLE
Update type definitions to be able to use array in filters.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -100,7 +100,7 @@ export namespace Tracer {
          * Datetime format (Using `Date Format`)
          */
         dateformat?: string;
-        filters?: FilterFunction[] | LevelOption<FilterFunction> | Array<FilterFunction | LevelOption<FilterFunction | FilterFunction[]>>;
+        filters?: FilterFunction[] | LevelOption<FilterFunction | FilterFunction[]> | Array<FilterFunction | LevelOption<FilterFunction | FilterFunction[]>>;
         /**
          * Output the log, if level of log larger than or equal to `level`.
          */


### PR DESCRIPTION
Because things like 
`filters : { info : [colors.green, colors.bold] }`
are not valid right now from typings, but actually you can use array in this line. 