### PR TITLE
fix bug then  when set allLogFile cannot delete old old files

### DIFF
--- a/lib/dailyfile.js
+++ b/lib/dailyfile.js
@@ -5,11 +5,11 @@ var os = require('os');
 var mkdirp = require('mkdirp');
 
 function checkLogFile(path) {
-    if(os.type() === 'Windows_NT') {
-        if(!fs.existsSync(path)) {
+    if (os.type() === 'Windows_NT') {
+        if (!fs.existsSync(path)) {
             mkdirp(path);
         }
-    }else {
+    } else {
         spawnSync('mkdir', ['-p', path]);
     }
 }
@@ -27,7 +27,7 @@ module.exports = function (conf) {
 
     function LogFile(prefix, date) {
         this.date = date;
-        this.path = tinytim.tim(_conf.logPathFormat, {root: _conf.root, prefix: prefix, date: date});
+        this.path = tinytim.tim(_conf.logPathFormat, { root: _conf.root, prefix: prefix, date: date });
         checkLogFile(_conf.root);
         this.stream = fs.createWriteStream(this.path, {
             flags: "a",
@@ -61,7 +61,7 @@ module.exports = function (conf) {
             }
             if (!allLogFile) {
                 allLogFile = _logMap.allLogFile = new LogFile(_conf.allLogsFileName, now);
-                spawn('find', ['./', '-type', 'f', '-name', '*.log', '-mtime', '+' + _conf.maxLogFiles, '-exec', 'rm', '{}', ';']);
+                spawn('find', [_conf.root, '-type', 'f', '-name', '*.log', '-mtime', '+' + _conf.maxLogFiles, '-exec', 'rm', '{}', ';']);
             }
             allLogFile.write(str);
         } else {


### PR DESCRIPTION
when allLogFile be set, this code "spawn('find', ['./', '-type', 'f', '-name', '*.log', '-mtime', '+' + _conf.maxLogFiles, '-exec', 'rm', '{}', ';']); " cannot find right old files in right directory.