### PR TITLE
Update type of depth property in inspectOpt

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,7 +120,7 @@ export namespace Tracer {
              * This is useful for inspecting large complicated objects.
              * Defaults to 2. To make it recurse indefinitely pass null.
              */
-            depth: number
+            depth: number | null
         };
 
         /**


### PR DESCRIPTION
If depth is set as `depth: null`, TypeScript compiler (with `"strict": true`) gives compile error.

Since null is a valid value, we can simply update the types file.